### PR TITLE
Convert `abs` tests to use interval framework

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -17,18 +17,11 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
-import {
-  f32Bits,
-  i32Bits,
-  TypeF32,
-  TypeI32,
-  TypeU32,
-  u32Bits,
-} from '../../../../../util/conversion.js';
+import { i32Bits, TypeF32, TypeI32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
+import { absInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -102,10 +95,7 @@ g.test('i32')
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
-    run(t, builtin('abs'), [TypeI32], TypeI32, cfg, [
+    run(t, builtin('abs'), [TypeI32], TypeI32, t.params, [
       // Min and max i32
       // If e evaluates to the largest negative value, then the result is e.
       { input: i32Bits(kBit.i32.negative.min), expected: i32Bits(kBit.i32.negative.min) },
@@ -167,20 +157,17 @@ g.test('f32')
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, Math.abs);
+      return makeUnaryF32IntervalCase(x, absInterval);
     };
 
     const cases: Array<Case> = [
-      { input: f32Bits(kBit.f32.infinity.negative), expected: f32Bits(kBit.f32.infinity.positive) },
-      { input: f32Bits(kBit.f32.infinity.positive), expected: f32Bits(kBit.f32.infinity.positive) },
-      ...fullF32Range().map(x => makeCase(x)),
-    ];
+      Number.NEGATIVE_INFINITY,
+      ...fullF32Range(),
+      Number.POSITIVE_INFINITY,
+    ].map(x => makeCase(x));
 
-    run(t, builtin('abs'), [TypeF32], TypeF32, cfg, cases);
+    run(t, builtin('abs'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1,5 +1,11 @@
 import { GPUTest } from '../../../gpu_test.js';
-import { compare, Comparator, FloatMatch, anyOf } from '../../../util/compare.js';
+import {
+  compare,
+  Comparator,
+  FloatMatch,
+  anyOf,
+  intervalComparator,
+} from '../../../util/compare.js';
 import {
   ScalarType,
   Scalar,
@@ -12,6 +18,7 @@ import {
   f32,
   f64,
 } from '../../../util/conversion.js';
+import { PointToInterval } from '../../../util/f32_interval.js';
 import { flushSubnormalNumber, isSubnormalNumber, quantizeToF32 } from '../../../util/math.js';
 
 // Helper for converting Values to Comparators.
@@ -439,4 +446,16 @@ export function makeBinaryF32Case(
   }
 
   return { input: [f32(param0), f32(param1)], expected: anyOf(...expected) };
+}
+
+/**
+ * Generates a Case for the param and unary interval generator provided.
+ * The Case will use use an IntervalComparator for matching results.
+ * @param param the param to pass into the unary operation
+ * @param op callback that implements generating an acceptance interval for a unary operation
+ */
+export function makeUnaryF32IntervalCase(param: number, op: PointToInterval) {
+  param = quantizeToF32(param);
+  const interval = op(param);
+  return { input: [f32(param)], expected: intervalComparator(interval) };
 }

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -1,6 +1,7 @@
 import { Colors } from '../../common/util/colors.js';
 
 import { f32, isFloatValue, Scalar, Value, Vector } from './conversion.js';
+import { F32Interval } from './f32_interval';
 import { correctlyRounded, oneULP, withinULP } from './math.js';
 
 /** Comparison describes the result of a Comparator function. */
@@ -57,6 +58,21 @@ export function ulpMatch(ulp: number): FloatMatch {
 export function correctlyRoundedMatch(): FloatMatch {
   return (got, expected) => {
     return correctlyRounded(f32(got), expected);
+  };
+}
+
+/**
+ * @returns a FloatMatch that return true iff |got| is contained in the interval
+ * |i|.
+ * The standard |expected| parameter is ignored
+ *
+ * NB: This will be removed at the end of transition to the new FP testing framework.
+ *
+ * @param i interval to test the |got| value against.
+ */
+export function intervalMatch(i: F32Interval): FloatMatch {
+  return (got, _) => {
+    return i.contains(got);
   };
 }
 
@@ -171,6 +187,26 @@ export function ulpComparator(x: number, target: Scalar, n: (x: number) => numbe
       matched: false,
       got: got.toString(),
       expected: `within ${c} * ULP (${ulp}) of ${target}`,
+    };
+  };
+}
+
+/** @returns a Comparator that checks whether a result is contained within a target interval
+ *
+ * NB: This will be removed at the end of transition to the new FP testing framework.
+ */
+export function intervalComparator(i: F32Interval): Comparator {
+  const match = intervalMatch(i);
+  return (got, _) => {
+    // The second param is ignored by match
+    const cmp = compare(got, f32(0.0), match);
+    if (cmp.matched) {
+      return cmp;
+    }
+    return {
+      matched: false,
+      got: got.toString(),
+      expected: `within ${i}`,
     };
   };
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -276,7 +276,6 @@ function roundAndFlushTernaryToInterval(
  * @param op operation defining the function being run
  * @returns a span over all of the outputs of op.impl
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function runPointOp(x: F32Interval, op: PointToIntervalOp): F32Interval {
   if (x.isPoint()) {
     return roundAndFlushPointToInterval(x.begin, op);
@@ -391,4 +390,15 @@ export function ulpInterval(n: number, numULP: number): F32Interval {
       return new F32Interval(impl_n - numULP * ulp, impl_n + numULP * ulp);
     },
   });
+}
+
+/** Calculate an acceptance interval for abs(n) */
+export function absInterval(n: number): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_n: number): F32Interval => {
+      return correctlyRoundedInterval(Math.abs(impl_n));
+    },
+  };
+
+  return runPointOp(toInterval(n), op);
 }


### PR DESCRIPTION
This also adds in things like the intervalComparator that will be used
by other tests.

Issue #792

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
